### PR TITLE
add conclusion box in red; add authors as comma-separated

### DIFF
--- a/themes/kube/layouts/shortcodes/target-enabling-packages.html
+++ b/themes/kube/layouts/shortcodes/target-enabling-packages.html
@@ -174,6 +174,7 @@
     <b>Disease Relevance:</b> {{ .TEP.disease_relevance }} <br>
     <b>Viral family:</b> {{ .TEP.asap.viral_family }} <br>
     <b>Viruses:</b> {{ .TEP.asap.viruses }} <br>
+    <b>Authors:</b> {{ with .TEP.contributors }}{{ delimit . ", "}}{{ end }} <br> 
     </div>
     
     <div class="prettybox success" data-component="prettybox"> 
@@ -184,6 +185,11 @@
     <div class="prettybox focus" data-component="prettybox">
         <h4>Scientific Background</h4>
         {{ .TEP.scientific_background | markdownify }}
+    </div>
+
+    <div class="prettybox error" data-component="prettybox">
+        <h4>Conclusion</h4>
+        {{ .TEP.conclusion | markdownify }}
     </div>
 
     <h4>Resources</h4>


### PR DESCRIPTION
Resolves https://github.com/asapdiscovery/asapdiscovery.github.io/issues/21 and https://github.com/asapdiscovery/asapdiscovery.github.io/issues/22. TEP view now looks like this:
![image](https://user-images.githubusercontent.com/43140137/232033688-7e136951-8fc5-4af3-a839-8da57e2a26fd.png)

Still need to refactor the way we show contributing authors, but we should do this as a sweep across all TEPs because they will all need to be adjusted, plus it will take some time to figure out the contributors per assay. Will use this form as a placeholder for now.