### PR TITLE
add PDB group decomposition URLs to `conclusion` sections & completed `contributors` in .yamls

### DIFF
--- a/data/outputs/TEPs/EV-D68-3C-protease.yaml
+++ b/data/outputs/TEPs/EV-D68-3C-protease.yaml
@@ -31,14 +31,13 @@ TEP:
   # Therapeutic area
   therapeutic_area: Infectious diseases
   # Disease relevance statement
-  disease_relevance: 3C proteases are a clinically validated target
+  disease_relevance: 3C proteases are a clinically validated target.
   # List of authors
+  # TODO: This should be pulled from the reported research products instead, and possibly renamed to "contributors"
   # TODO: This should be pulled from the reported research products instead, and possibly renamed to "contributors"
   contributors:
   - Lizbé Koekemoer
   - Annette von Delft
-  # TODO: This should be pulled from the reported research products instead, and possibly renamed to "contributors"
-  contributors:
   - Blake Balcomb
   - Charlie Tomlinson
   - Charline Giroud
@@ -49,6 +48,7 @@ TEP:
   - Peter Marples
   - Ryan Lithgo
   - Xiaomin Ni
+  fragscreen_pdb_group_decomposition: N/A
   # Summary of Project
   # This is Markdown: See https://www.markdownguide.org/ for guide
   summary: >

--- a/data/outputs/TEPs/SARS-CoV-2-MPRO.yaml
+++ b/data/outputs/TEPs/SARS-CoV-2-MPRO.yaml
@@ -35,7 +35,7 @@ TEP:
   therapeutic_area: Infectious diseases
   # Disease relevance statement
   disease_relevance: The SARS-Cov-2 main protease (Mpro) is responsible for viral polyprotein processing and therefore a therapeutic target.
-  list of authors:
+  contributors:
   - Alice Douangamath
   - Daren Fearon
   - Paul Gehrtz
@@ -87,7 +87,9 @@ TEP:
     main protease by small molecule fragment molecules. Together with the established enzymatic assays, it
     forms the bases for rational, structure-based drug development. The usefulness of the data and protocols
     presented in this TEP have been demonstrated by the [COVID Moonshot consortium](https://covid.postera.ai/covid) successfully
-    developing sub-micromolar binders, that are now in lead optimisation.
+    developing sub-micromolar binders, that are now in lead optimisation. 
+
+    Fragment screen PDB group deposition: https://www.rcsb.org/groups/summary/entry/G_1002153
   # List of resources associated with this TEP
   resources:
     # Construct / plasmid resource

--- a/data/outputs/TEPs/SARS-CoV-2-NSP13.yaml
+++ b/data/outputs/TEPs/SARS-CoV-2-NSP13.yaml
@@ -35,10 +35,9 @@ TEP:
   therapeutic_area: Infectious diseases
   # Disease relevance statement
   disease_relevance: NSP13 is a DNA/RNA helicase that is essential for SARS-Cov-2 replication, inhibitors to NSP13 could be developed as antiviral drugs.
-  list of authors:
-  - Opher Gileadi.
   # TODO: This should be pulled from the reported research products instead, and possibly renamed to "contributors"
   contributors:
+  - Opher Gileadi.
   - Joseph Newman
   - Yuliana Yosaatmadja
   - Alice Douangamath
@@ -90,6 +89,8 @@ TEP:
     DNA/RNA interface which may be developed into ATP or DNA competitive inhibitors. Alternatively, several
     pockets were discovered at interfaces between domains that could lead to allosteric inhibitors that prevent
     domain movements that occur as part of the helicase catalytic cycle.
+
+    Fragment screen PDB group deposition: https://www.rcsb.org/groups/summary/entry/G_1002164
   # List of resources associated with this TEP
   resources:
     # Construct / plasmid resource

--- a/data/outputs/TEPs/SARS-CoV-2-NSP15.yaml
+++ b/data/outputs/TEPs/SARS-CoV-2-NSP15.yaml
@@ -35,10 +35,9 @@ TEP:
   therapeutic_area: Infectious diseases
   # Disease relevance statement
   disease_relevance: NSP15 is a nidoviral RNA uridylate‐specific endoribonuclease (NendoU) from SARS-CoV-2, likely involved in innate immune evasion
-  list of authors:
-  - Andre Schutzer Godoy
   # TODO: This should be pulled from the reported research products instead, and possibly renamed to "contributors"
   contributors:
+  - Andre Schutzer Godoy
   - Tobias Krojer
   - Aline M. Nakamura
   - Alice Douangamath

--- a/data/outputs/TEPs/SARS-CoV-2-NSP3-MAC1.yaml
+++ b/data/outputs/TEPs/SARS-CoV-2-NSP3-MAC1.yaml
@@ -41,7 +41,6 @@ TEP:
   - Marion Schuller
   - Galen J. Correy
   - Stefan Gahbauer
-  - a merry band of players
   # Summary of Project
   # This is Markdown: See https://www.markdownguide.org/ for guide
   summary: >
@@ -65,6 +64,8 @@ TEP:
   # This is Markdown: See https://www.markdownguide.org/ for guide    
   conclusion: >
     Here we have established a purification protocol for recombinant Nsp3 Mac1 from Sars-CoV-2 and established a robust crystallisation suitable for fragment screening. We have performed a substantial fragment screening campaign and identified many hits which were validated by biophysical assays established in this work. The ligands and assays established in this work will pave the way for future drug discovery endeavours targeting Nsp3 Mac1.
+  
+    Fragment screen PDB group deposition: https://www.rcsb.org/groups/summary/entry/G_1002238
   # List of resources associated with this TEP
   resources:
     # Construct / plasmid resource

--- a/data/outputs/TEPs/TEP-ZIKA-NS2B-NS3.yaml
+++ b/data/outputs/TEPs/TEP-ZIKA-NS2B-NS3.yaml
@@ -35,13 +35,12 @@ TEP:
   therapeutic_area: Infectious diseases
   # Disease relevance statement
   disease_relevance: NS3 encodes protease that is important for processing the viral polyprotein 
-  list of authors:
+  # TODO: This should be pulled from the reported research products instead, and possibly renamed to "contributors"
+  contributors:
   - Lizbé Koekemoer
   - Michael Fairhead
   - Xiaomin Ni
   - Blake Balcomb
-  # TODO: This should be pulled from the reported research products instead, and possibly renamed to "contributors"
-  contributors:
   - Daren Fearon
   - Andre de Godoy
   - Charlie Tomlinson 

--- a/data/outputs/TEPs/ZIKA-NS3-helicase.yaml
+++ b/data/outputs/TEPs/ZIKA-NS3-helicase.yaml
@@ -36,9 +36,9 @@ TEP:
   # Disease relevance statement
   disease_relevance: NS3 encodes a helicase that is important for viral replication
   list of authors:
-  - Andre Schutzer Godoy
   # TODO: This should be pulled from the reported research products instead, and possibly renamed to "contributors"
   contributors:
+  - Andre Schutzer Godoy
   - Nathalya Cristina de Moraes Roso Mesquita
   - Gabriela Dias Noske
   - Rafaela Sachetto Fernandes
@@ -67,6 +67,8 @@ TEP:
   # This is Markdown: See https://www.markdownguide.org/ for guide    
   conclusion: >
     Here we have established a purification protocol for recombinant NS3 helicase from Zika viruses and established a robust crystallisation suitable for fragment screening. We have performed a substantial fragment screening campaign and identified many hits.
+  
+    Fragment screen PDB group deposition: https://www.rcsb.org/groups/summary/entry/G_1002158
   # List of resources associated with this TEP
   resources:
     # Construct / plasmid resource


### PR DESCRIPTION
added URLs of group decompositions on the PDB to TEPs that have one (see https://www.notion.so/asapdiscovery/Anti-Viral-Fragment-Screens-1dbf8450c1d0432aa0635fa2b73b7503). Decided to take the easy way out, now all TEPs with this url will have the URL at the end of the conclusion render (see https://github.com/asapdiscovery/asapdiscovery.github.io/pull/25).

Also cheated and did a second adjustment - now removed `author list` from all .yamls and migrated all those names to `contributors`, so at least now all scientists are being mentioned. For a later iteration we still have to split `contributors` across assays rather than rendering in this top box.