### PR TITLE
thicken horizontal divider and center tep titles

### DIFF
--- a/themes/kube/layouts/shortcodes/target-enabling-packages.html
+++ b/themes/kube/layouts/shortcodes/target-enabling-packages.html
@@ -17,7 +17,7 @@
     
     <!-- {{ with .TEP.name }} {{ printf "### %s" . | markdownify }} {{ end }} -->
 
-    {{ with .TEP.name }} <h3 id={{ $program_nickname }}>{{ . }}</h3> {{ end }}
+    {{ with .TEP.name }} <h3 style="text-align: center;" id={{ $program_nickname }}>{{ . }}</h3> {{ end }}
     
     <!-- Status is shown as stages instead-->
     <!--
@@ -339,6 +339,6 @@
 
     {{ end }}
 
-    <hr>
+    <hr style="height:5px;border:none;color:#333;background-color:#333;">
 
 {{ end }}


### PR DESCRIPTION
based on feedback from Frank and @LizbeK, adjusted TEPs to have clearer dividers. Also centered TEP titles which makes the division even clearer imo. Example:
![image](https://user-images.githubusercontent.com/43140137/232715619-e8d9879e-434b-49f8-bd1e-7354779f2282.png)
 
I also found out why the download button was appearing in odd places in https://github.com/asapdiscovery/asapdiscovery.github.io/pull/24: I had inserted the button in  `themes/kube/layouts/outputs/single.html` whereas I should have inserted it in `themes/kube/layouts/shortcodes/target-enabling-packages.html`.