### PR TITLE
Fix #127 : Update TEP status graphic to replace "Compound design and TEP validation" with "First-round progression for TEP validation"

### DIFF
--- a/themes/kube/layouts/partials/TEP.html
+++ b/themes/kube/layouts/partials/TEP.html
@@ -226,7 +226,7 @@
             </td>
             <td>
                 <!-- Compound design and TEP evaluation -->
-                {{ $text := "Compound design and TEP validation" }}
+                {{ $text := "First-round progression for TEP validation" }}
                 {{ $status := $TEP_stages.tep_evaluation }}
                 {{ $icon := "not-started" }}
                 {{ if strings.Contains $status "completed" }}


### PR DESCRIPTION
Fixes #127 