### PR TITLE
Remove deprecated GA template

### DIFF
--- a/themes/kube/layouts/_default/baseof.html
+++ b/themes/kube/layouts/_default/baseof.html
@@ -24,7 +24,7 @@
   <!-- Site verification -->
   {{ if .IsHome }} {{ partial "site-verification" . }} {{ end }}
   <!-- add googleAnalytics in config.toml -->
-  {{ template "_internal/google_analytics_async.html" . }} 
+  {{ template "_internal/google_analytics.html" . }}
   <!-- GDPR compliant google tag analytics -->
   {{ partial "cookie-consent.html" .}}
 


### PR DESCRIPTION
As per changes upstream https://github.com/gohugoio/hugo/commit/ebfca61ac4d4b62b3e4a50477826a85c06b44552

The google analytics async template is deprecated. This PR fixes the problem with the template not being found in https://github.com/asapdiscovery/asapdiscovery.github.io/actions/runs/8710408460/job/23892253853