### PR TITLE
add DMS links for ZIKV NS2B3 and RdRp

### DIFF
--- a/content/outputs/circulating-variants.md
+++ b/content/outputs/circulating-variants.md
@@ -1,7 +1,7 @@
 ---
 weight: 60
-title: Analysis of Circulating Variants
-description: Analysis of circulating variants to identify potential resistance liabilities in functionally tolerated mutations
+title: Analysis of Viral Mutations
+description: Analysis of circulating and experimental variants to identify potential resistance liabilities in functionally tolerated mutations
 toc: true
 draft: false
 ---

--- a/data/outputs/circulating_variants.yaml
+++ b/data/outputs/circulating_variants.yaml
@@ -127,3 +127,25 @@ MOONSHOT-COV-MPRO:
   events:
   - date: 2023-01-31
     description: Preprint and interactive mutation viewer posted.
+
+ASAP-ZIKV-NS2B3:
+  name: Analysis of mutational space with Deep Mutational Scanning of ZIKV NS2B/3 protease
+  description: Dataset download of fitness data gathered by Deep Mutational Scanning performed by Evans lab, analyzed by Bloom lab
+  links:
+  - name: dataset download
+    url: https://github.com/jbloomlab/ZIKV_DMS_NS3_EvansLab/tree/master
+  events:
+  - date: 2023-11-01
+    description: Initial version of analyzed data posted.
+  projects: [Project 1]
+
+ASAP-ZIKV-RdRp-polymerase:
+  name: Analysis of mutational space with Deep Mutational Scanning of ZIKV RdRp polymerase (NS5)
+  description: Dataset download of fitness data gathered by Deep Mutational Scanning performed by Evans lab, analyzed by Bloom lab
+  links:
+  - name: dataset download
+    url: https://github.com/jbloomlab/ZIKV_DMS_NS5_EvansLab/tree/IFN_signaling
+  events:
+  - date: 2024-04-01
+    description: Initial version of analyzed data posted.
+  projects: [Project 1]


### PR DESCRIPTION
populate `outputs` with links to Bloom lab github pages for DMS analyses for ZIKV NS2B3 and RdRp. 

looks like this: 
![image](https://github.com/asapdiscovery/asapdiscovery.github.io/assets/43140137/e5e44e2c-2f20-4cbb-b267-db9543821a21)
