### PR TITLE
add agreements output

### DIFF
--- a/content/outputs/ip-agreement.md
+++ b/content/outputs/ip-agreement.md
@@ -1,0 +1,9 @@
+---
+weight: 20
+title: IP Agreements
+description: Open Science and Intellectual Property Agreements designed by ASAP
+toc: true
+---
+
+
+{{< ip-agreement >}}

--- a/data/outputs/ip_agreement.yaml
+++ b/data/outputs/ip_agreement.yaml
@@ -1,0 +1,9 @@
+asapdiscovery:
+  name: "Open Science and Intellectual Property Agreement"
+  description: Griffen, E., & Boulet, P. (2024). ASAP Policy on Intellectual Property Management and Open Science Disclosure (1.0). Zenodo.
+  permalink: http://asapdiscovery.org/outputs/ip-agreement/#asapdiscovery
+  projects: [Project 5, Project 6, Admin Core]
+  links:
+  - name: Publication
+    url: https://doi.org/10.5281/zenodo.12191567
+

--- a/themes/kube/layouts/shortcodes/ip-agreement.html
+++ b/themes/kube/layouts/shortcodes/ip-agreement.html
@@ -1,0 +1,7 @@
+<!-- TODO: How should we sort the target data? -->
+{{ range $package, $output := $.Site.Data.outputs.ip_agreement }}
+
+    {{ $output := merge $output (dict "id" $package) }}
+    {{ partial "research-output.html" $output }}
+
+{{ end }}


### PR DESCRIPTION
adds outputs reference to IP agreements as drafted by Ed Griffen. Views:

![image](https://github.com/asapdiscovery/asapdiscovery.github.io/assets/43140137/cffb3c23-23c1-41e3-a7f2-22f01db7265b)


and clicking the `IP Agreements` blue button leads to:

![image](https://github.com/asapdiscovery/asapdiscovery.github.io/assets/43140137/13ad64dc-da3a-4db3-92f8-b37f5972433c)


where of course the `Publication` URL links to the zenodo page.