### PR TITLE
Fix #212 : Fix "About Us" link in footer

### DIFF
--- a/themes/kube/layouts/partials/footer.html
+++ b/themes/kube/layouts/partials/footer.html
@@ -3,7 +3,7 @@
       <ul>
         <li><span>ASAP Discovery</span></li>
         <li>
-          <a href="/concept">About Us</a>
+          <a href="https://www.choderalab.org/news/2021/10/26/asap-avidd-proposal">About Us</a>
         </li>
         <li>
           <a href="https://github.com/asapdiscovery/asapdiscovery.github.io/blob/ef39d2ca859fd53561b9e6da52db5e98e59de6e5/assets/images/icons/README.md">Image Credits</a>


### PR DESCRIPTION
Fix #212 : Fixes "About Us" link in footer