### PR TITLE
Fix #208 : Move "Click on any shaded box to view data..." from bottom to top of pipeline figure

### DIFF
--- a/themes/kube/layouts/section/pipeline.html
+++ b/themes/kube/layouts/section/pipeline.html
@@ -6,6 +6,11 @@
 <div id="hero" class="wrap">
   <h1>{{.Title }}</h1>
     <p>{{.Params.description}}</p>
+
+    <center>
+      <i>Click on any shaded box to view data and resources associated with that stage.</i>
+    </center>
+        
 </div>
 <div id="main">
 
@@ -16,7 +21,6 @@
 <!-- Define width for icons -->
 <!-- TODO: Can we shrink width as needed to make sure we fit on mobile without wrapping icons? -->
 {{ $icon_width := "28" }}
-
 
 <div class="container">
 
@@ -137,10 +141,6 @@
       &nbsp
     </div>
   {{ end }}
-
-  <center>
-    <i>Click on any shaded box to view data and resources associated with that stage.</i>
-  </center>
 
   <br>
 


### PR DESCRIPTION
Fixes #208 : Moves "Click on any shaded box to view data..." from bottom to top of pipeline figure.

Old:
![image](https://github.com/user-attachments/assets/85dad4cb-c95c-4f3a-b99f-915194e12e51)
New:
![image](https://github.com/user-attachments/assets/d985eabc-7b92-4bb5-bb8d-533cddfa7aea)
