### PR TITLE
Fix #197 : Build and deploy with latest hugo (instead of pinning to 0.125.5)

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,9 +17,9 @@ jobs:
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
-        with:
-          hugo-version: '0.125.5'
-          # extended: true
+        #with:
+        #  hugo-version: '0.125.5'
+        #  # extended: true
 
       - name: Build
         run: hugo --minify


### PR DESCRIPTION
Fixes #197 : Removes pins to 0.125.5

I suspect #214 fixed the underlying issue.