### PR TITLE
Using transform.Unmarshal instead of deprecated GetCSV

### DIFF
--- a/themes/kube/layouts/partials/TEP.html
+++ b/themes/kube/layouts/partials/TEP.html
@@ -5,7 +5,18 @@
 {{ $font := resources.GetRemote "https://github.com/google/fonts/raw/47ea46c388b5e33496168d9fb4e7ffb43e1142f4/apache/roboto/static/Roboto-Black.ttf" }}
 {{ $fontsize := 26 }}
 
-{{ $TEP_status := getCSV "," "https://docs.google.com/spreadsheets/d/e/2PACX-1vQit4u7d3lBlnX0Tu79Ep6pxSLiCvDn1PppulKgs5-C0SM0jlT9C491wstbZAJk7nm5BhJUlc9Op1gA/pub?output=csv" }}
+{{ $TEP_status := dict }}
+{{ $url := "https://docs.google.com/spreadsheets/d/e/2PACX-1vQit4u7d3lBlnX0Tu79Ep6pxSLiCvDn1PppulKgs5-C0SM0jlT9C491wstbZAJk7nm5BhJUlc9Op1gA/pub?output=csv" }}
+{{ with resources.GetRemote $url }}
+    {{ with .Err }}
+        {{ errorf "%s" . }}
+    {{ else }}
+        {{ $options := dict "delimiter" "," }}
+        {{ $TEP_status = transform.Unmarshal $options . }}
+    {{ end }}
+{{ else }}
+    {{ errorf "Unable to get remote resource %q" $url }}
+{{ end }}
 
 {{ $program_code := .asap.program_code }}
 {{ $program_nickname := .asap.program_nickname }}

--- a/themes/kube/layouts/shortcodes/TEPs.html
+++ b/themes/kube/layouts/shortcodes/TEPs.html
@@ -4,7 +4,19 @@
 {{ $fontsize := 26 }}
 
 <!-- Get TEP in-progress status -->
-{{ $TEP_status := getCSV "," "https://docs.google.com/spreadsheets/d/e/2PACX-1vQit4u7d3lBlnX0Tu79Ep6pxSLiCvDn1PppulKgs5-C0SM0jlT9C491wstbZAJk7nm5BhJUlc9Op1gA/pub?gid=125511302&single=true&output=csv" }}
+{{ $TEP_status := dict }}
+{{ $url := "https://docs.google.com/spreadsheets/d/e/2PACX-1vQit4u7d3lBlnX0Tu79Ep6pxSLiCvDn1PppulKgs5-C0SM0jlT9C491wstbZAJk7nm5BhJUlc9Op1gA/pub?gid=125511302&single=true&output=csv" }}
+{{ with resources.GetRemote $url }}
+    {{ with .Err }}
+        {{ errorf "%s" . }}
+    {{ else }}
+        {{ $options := dict "delimiter" "," }}
+        {{ $TEP_status = transform.Unmarshal $options . }}
+    {{ end }}
+{{ else }}
+    {{ errorf "Unable to get remote resource %q" $url }}
+{{ end }}
+
 
 <!-- TODO: How should we sort the target data? -->
 {{ range $.Site.Data.outputs.TEPs }}


### PR DESCRIPTION
These set of changes use `transform.Unmarshal` with a remote resource (google drive csv file) instead of the deprecated `GetCSV` function.

Solves #223 