### PR TITLE
fix for error catching with newer hugo version 

### DIFF
--- a/themes/kube/layouts/partials/TEP.html
+++ b/themes/kube/layouts/partials/TEP.html
@@ -7,7 +7,7 @@
 
 {{ $TEP_status := dict }}
 {{ $url := "https://docs.google.com/spreadsheets/d/e/2PACX-1vQit4u7d3lBlnX0Tu79Ep6pxSLiCvDn1PppulKgs5-C0SM0jlT9C491wstbZAJk7nm5BhJUlc9Op1gA/pub?output=csv" }}
-{{ with resources.GetRemote $url }}
+{{ with try (resources.GetRemote $url) }}
     {{ with .Err }}
         {{ errorf "%s" . }}
     {{ else }}

--- a/themes/kube/layouts/shortcodes/TEPs.html
+++ b/themes/kube/layouts/shortcodes/TEPs.html
@@ -6,7 +6,7 @@
 <!-- Get TEP in-progress status -->
 {{ $TEP_status := dict }}
 {{ $url := "https://docs.google.com/spreadsheets/d/e/2PACX-1vQit4u7d3lBlnX0Tu79Ep6pxSLiCvDn1PppulKgs5-C0SM0jlT9C491wstbZAJk7nm5BhJUlc9Op1gA/pub?gid=125511302&single=true&output=csv" }}
-{{ with resources.GetRemote $url }}
+{{ with try (resources.GetRemote $url) }}
     {{ with .Err }}
         {{ errorf "%s" . }}
     {{ else }}


### PR DESCRIPTION
Fixing https://github.com/asapdiscovery/asapdiscovery.github.io/actions/runs/12993801197/job/36236818242#step:4:10

Newer versions of hugo (`>=0.141`) now expect a `try` statement for catching errors. Hopfully this will fix the CI/build.