### PR TITLE
Updating deprecated ubuntu runner to 22.04

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
According to https://github.com/actions/runner-images/issues/11101 the ubuntu 20.04 runner is now deprecated. These changes are now updating it to `22.04` in order to try to use the closest one to the one we were already using. I guess we could also try just using the `ubuntu-latest` to avoid this in the future, but I foresee more changes using that one.